### PR TITLE
Support alpha transparency

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,12 +162,29 @@ function alphaBlend(cssForeground, cssBackground) {
 	return result;
 }
 
-function getContrastRatio(foreground, background) {
+function getContrastRatioOpaque(foreground, background) {
 	var L1 = getRelativeLuminance(background);
 	var L2 = getRelativeLuminance(alphaBlend(foreground, background));
 
 	// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
 	return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+}
+
+function getContrastRatio(foreground, background) {
+	var backgroundOnWhite = alphaBlend(background, '#fff');
+	var backgroundOnBlack = alphaBlend(background, '#000');
+
+	var LWhite = getRelativeLuminance(backgroundOnWhite);
+	var LBlack = getRelativeLuminance(backgroundOnBlack);
+	var LForeground = getRelativeLuminance(foreground);
+
+	if (LWhite < LForeground) {
+		return getContrastRatioOpaque(foreground, backgroundOnWhite);
+	} else if (LBlack > LForeground) {
+		return getContrastRatioOpaque(foreground, backgroundOnBlack);
+	} else {
+		return 1;
+	}
 }
 
 function getFontSize(cssLength) {

--- a/index.js
+++ b/index.js
@@ -149,9 +149,22 @@ function getRelativeLuminance(cssColor) {
 	return L;
 }
 
+function alphaBlend(cssForeground, cssBackground) {
+	var foreground = onecolor(cssForeground);
+	var background = onecolor(cssBackground);
+	var result = onecolor('#fff');
+	var a = foreground.alpha();
+
+	result._red   = foreground._red   * a + background._red   * (1 - a);
+	result._green = foreground._green * a + background._green * (1 - a);
+	result._blue  = foreground._blue  * a + background._blue  * (1 - a);
+
+	return result;
+}
+
 function getContrastRatio(foreground, background) {
 	var L1 = getRelativeLuminance(background);
-	var L2 = getRelativeLuminance(foreground));
+	var L2 = getRelativeLuminance(alphaBlend(foreground, background));
 
 	// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
 	return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);

--- a/index.js
+++ b/index.js
@@ -109,15 +109,7 @@ module.exports = postcss.plugin('postcss-wcag-contrast', function (rawopts) {
 				fontweight = fallbackweight || 400;
 			}
 
-			// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
-			var backgroundLuminance = getRelativeLuminance(background);
-			var foregroundLuminance = getRelativeLuminance(foreground);
-
-			// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
-			var L1 = Math.max(backgroundLuminance, foregroundLuminance);
-			var L2 = Math.min(backgroundLuminance, foregroundLuminance);
-
-			var contrastRatio = getContrastRatio(L1, L2);
+			var contrastRatio = getContrastRatio(foreground, background);
 
 			// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#larger-scaledef
 			var isLargeScale = fontsize >= 24 || fontsize >= 14 * (96 / 72) && fontweight >= 700;
@@ -145,6 +137,7 @@ module.exports = postcss.plugin('postcss-wcag-contrast', function (rawopts) {
 });
 
 function getRelativeLuminance(cssColor) {
+	// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
 	var color = onecolor(cssColor);
 
 	var R = color._red   <= 0.03928 ? color._red   / 12.92 : Math.pow((color._red   + 0.055) / 1.055, 2.4);
@@ -156,8 +149,12 @@ function getRelativeLuminance(cssColor) {
 	return L;
 }
 
-function getContrastRatio(L1, L2) {
-	return (L1 + 0.05) / (L2 + 0.05);
+function getContrastRatio(foreground, background) {
+	var L1 = getRelativeLuminance(background);
+	var L2 = getRelativeLuminance(foreground));
+
+	// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+	return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
 }
 
 function getFontSize(cssLength) {

--- a/test.js
+++ b/test.js
@@ -43,6 +43,17 @@ var tests = {
 			options: {
 				compliance: 'AAA'
 			}
+		},
+		'alpha': {
+			message: 'supports alpha transparancy',
+			warning: 4
+		},
+		'alpha:aaa': {
+			message: 'supports alpha transparancy',
+			warning: 6,
+			options: {
+				compliance: 'AAA'
+			}
 		}
 	}
 };

--- a/test/alpha.css
+++ b/test/alpha.css
@@ -1,0 +1,39 @@
+.a {
+	background-color: rgba(0, 0, 0, 0.2);
+	color: #fff;
+}
+
+.b {
+	background-color: rgba(0, 0, 0, 0.5);
+	color: #fff;
+}
+
+.c {
+	background-color: rgba(0, 0, 0, 0.6);
+	color: #fff;
+}
+
+.d {
+	background-color: rgba(0, 0, 0, 0.8);
+	color: #fff;
+}
+
+.e {
+	background-color: #fff;
+	color: rgba(0, 0, 0, 0.4);
+}
+
+.f {
+	background-color: #fff;
+	color: rgba(0, 0, 0, 0.5);
+}
+
+.g {
+	background-color: #fff;
+	color: rgba(0, 0, 0, 0.6);
+}
+
+.h {
+	background-color: #fff;
+	color: rgba(0, 0, 0, 0.7);
+}


### PR DESCRIPTION
Alpha transparency can negatively impact color contrast. I extended your algorithm based on the work of [lea verou](http://lea.verou.me/2012/10/easy-color-contrast-ratios/). More details on the algorithm can be found in [this article](http://tobib.spline.de/xi/posts/2016-03-05-color-contrast/). It is a bit complex, but here is the basic idea:

- If the foreground is transparent, we can just blend it onto the background to get to the "actual" color.
- If the background is transparent, we do not know what is behind it. But we know the extremes: The minimum/maximum possible luma would result from the background blended on black/white.
  - If the foreground luma is somewhere in that range, the worst case is a contrast ratio of 1.
  - If the foreground luma is higher than that, the worst case can be calculated with `backgroundOnWhite`
  - If the foreground luma is lower than that, the worst case can be calculated with `backgroundOnBlack`

I think it is fair to use the worst case here because transparent backgrounds are mostly used on top of images rather than a solid color. It is very likely that the worst case will occur *somewhere* in that image.