### PR TITLE
bug: fix unrecognised named colors in backgroud shorthand

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -64,6 +64,11 @@ module.exports = {
 				compliance: 'AAA'
 			},
 			expect: 'alpha.css'
-		}
+		},
+		'named-colors': {
+			message: 'supports named colors',
+			warning: 4,
+			expect: 'named-colors.css'
+		},
 	}
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const onecolor = require('onecolor');
+const expand   = require('css-shorthand-expand');
 const postcss  = require('postcss');
 const comma    = postcss.list.comma;
 const space    = postcss.list.space;
@@ -63,12 +64,11 @@ module.exports = postcss.plugin('postcss-wcag-contrast', (opts) => {
 				} else if (node.prop === 'background') {
 					// split background by comma and space
 					comma(node.value).forEach((commaSplitValue) => {
-						space(commaSplitValue).forEach((spaceSplitValue) => {
-							// conditionally set the the background color
-							if (cssColorRegExp.test(spaceSplitValue)) {
-								background = spaceSplitValue;
-							}
-						});
+						const expanded = expand('background', commaSplitValue);
+
+						if (expanded['background-color']) {
+							background = expanded['background-color'];
+						}
 					});
 				} else if (node.type === 'comment') {
 					if (cssParamsRegExp.test(node.text)) {

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = postcss.plugin('postcss-wcag-contrast', (opts) => {
 						}
 					});
 				} else if (node.prop === 'background') {
-					// split background by comma and space
+					// split background by comma
 					comma(node.value).forEach((commaSplitValue) => {
 						const expanded = expand('background', commaSplitValue);
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
+    "css-shorthand-expand": "^1.2.0",
     "onecolor": "^3.0.4",
     "postcss": "^6.0.1"
   },

--- a/test/named-colors.css
+++ b/test/named-colors.css
@@ -1,0 +1,29 @@
+.a {
+	background-color: white;
+	color: black;
+}
+
+.b {
+	background: white;
+	color: black;
+}
+
+.c {
+	background-color: white;
+	color: white;
+}
+
+.d {
+	background: white;
+	color: white;
+}
+
+.e {
+	background-color: black;
+	color: black;
+}
+
+.f {
+	background: black;
+	color: black;
+}


### PR DESCRIPTION
The current `cssColorRegExp` regex does not account for named colors, so fixing this by introducing a dependency [`css-shorthand-expand`](https://github.com/kapetan/css-shorthand-expand) which supports expanding the `background` shorthand as well as other properties.

Note: I noticed no lock file is committed in the repository so I did not add it.
Note 2: There seems to be 3 moderate security vulnerabilities after running `npm install` 